### PR TITLE
fix: Rename references to hive metastore

### DIFF
--- a/deploy/helm/hello-world-operator/crds/crds.yaml
+++ b/deploy/helm/hello-world-operator/crds/crds.yaml
@@ -25,7 +25,7 @@ spec:
             spec:
               properties:
                 clusterConfig:
-                  description: General Hive metastore cluster settings
+                  description: General Hello World cluster settings
                   properties:
                     listenerClass:
                       default: cluster-internal

--- a/rust/operator-binary/src/affinity.rs
+++ b/rust/operator-binary/src/affinity.rs
@@ -39,7 +39,7 @@ mod tests {
     #[case(HelloRole::Server)]
     fn test_affinity_defaults(#[case] role: HelloRole) {
         let input = r#"
-        apiVersion: hive.stackable.tech/v1alpha1
+        apiVersion: hello.stackable.tech/v1alpha1
         kind: HelloCluster
         metadata:
           name: hello-world

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -81,7 +81,7 @@ pub enum Error {
     InternalOperatorFailure { source: crate::crd::Error },
     #[snafu(display("object defines no namespace"))]
     ObjectHasNoNamespace,
-    #[snafu(display("object defines no metastore role"))]
+    #[snafu(display("object defines no hello role"))]
     NoServerRole,
     #[snafu(display("failed to calculate global service name"))]
     GlobalServiceNameNotFound,
@@ -539,7 +539,7 @@ fn build_server_rolegroup_statefulset(
     resolved_product_image: &ResolvedProductImage,
     hello_role: &HelloRole,
     role_group_ref: &RoleGroupRef<HelloCluster>,
-    metastore_config: &HashMap<PropertyNameKind, BTreeMap<String, String>>,
+    rolegroup_config: &HashMap<PropertyNameKind, BTreeMap<String, String>>,
     merged_config: &HelloConfig,
     sa_name: &str,
 ) -> Result<StatefulSet> {
@@ -556,7 +556,7 @@ fn build_server_rolegroup_statefulset(
             name: APP_NAME.to_string(),
         })?;
 
-    for (property_name_kind, config) in metastore_config {
+    for (property_name_kind, config) in rolegroup_config {
         if property_name_kind == &PropertyNameKind::Env {
             // overrides
             for (property_name, property_value) in config {

--- a/rust/operator-binary/src/crd.rs
+++ b/rust/operator-binary/src/crd.rs
@@ -87,7 +87,7 @@ pub enum Error {
     )
 )]
 pub struct HelloClusterSpec {
-    /// General Hive metastore cluster settings
+    /// General Hello World cluster settings
     pub cluster_config: HelloClusterConfig,
     /// Cluster operations like pause reconciliation or cluster stop.
     #[serde(default)]


### PR DESCRIPTION
# Description

Some part of the code and of the CRD description are referring to Hive Metastore which should probably be changed.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
